### PR TITLE
Don't merge: Use matplotlib widget backend instead of notebook

### DIFF
--- a/notebooks/3_using_external_libraries/2_plotting-with-matplotlib.ipynb
+++ b/notebooks/3_using_external_libraries/2_plotting-with-matplotlib.ipynb
@@ -84,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We here activate the `notebook` backend which provides interactive plots in the Jupyter notebook (for static plots, you can use the `inline` backend, which is the current default for Jupyter)"
+    "We here activate the `widget` backend which provides interactive plots in Jupyter (for static plots, you can use the `inline` backend, which is the current default for Jupyter)"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {

--- a/notebooks/3_using_external_libraries/3_ipywidgets.ipynb
+++ b/notebooks/3_using_external_libraries/3_ipywidgets.ipynb
@@ -1223,7 +1223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {
@@ -1353,7 +1353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/notebooks/3_using_external_libraries/4_fitting-scipy.ipynb
+++ b/notebooks/3_using_external_libraries/4_fitting-scipy.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {

--- a/notebooks/3_using_external_libraries/5_data_analysis_library_pandas.ipynb
+++ b/notebooks/3_using_external_libraries/5_data_analysis_library_pandas.ipynb
@@ -1286,7 +1286,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {

--- a/solutions/3_using_external_libraries/2_plotting-with-matplotlib-solutions.ipynb
+++ b/solutions/3_using_external_libraries/2_plotting-with-matplotlib-solutions.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {

--- a/solutions/3_using_external_libraries/3_ipywidgets-solutions.ipynb
+++ b/solutions/3_using_external_libraries/3_ipywidgets-solutions.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {

--- a/solutions/3_using_external_libraries/4_fitting-scipy-solution.ipynb
+++ b/solutions/3_using_external_libraries/4_fitting-scipy-solution.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib widget"
    ]
   },
   {


### PR DESCRIPTION
The `notebook` backend doesn't work on JupyterLab.